### PR TITLE
bugfix exclusion mask

### DIFF
--- a/R/getNSetterFunsInternal.R
+++ b/R/getNSetterFunsInternal.R
@@ -7,8 +7,8 @@
 #' @param value A logical vector of the length of the samples. If \code{TRUE},
 #'             the corresponding sample will be excluded from the autoencoder
 #'             fit.
-#' @param aeMatrix If \code{TRUE}, it returns a 0-1 matrix for the 
-#'             internal autoencoder functions
+#' @param aeMatrix If \code{TRUE}, it returns a 0/1 matrix for the 
+#'             internal autoencoder functions in the form of feature x sample
 #' @return The exclusion vector/matrix.
 #' 
 #' @name sampleExclusionMask
@@ -23,11 +23,12 @@
 #' 
 #' @export sampleExclusionMask
 sampleExclusionMask <- function(ods, aeMatrix=FALSE){
-    ans <- rep(FALSE, ncol(ods))
     if('exclude' %in% colnames(colData(ods))){
         ans <- colData(ods)[['exclude']]
-        names(ans) <- colnames(ods)
+    } else {
+        ans <- rep(FALSE, ncol(ods))
     }
+    names(ans) <- colnames(ods)
     
     if(isTRUE(aeMatrix)){
         ans <- as.integer(vapply(ans, isFALSE, FALSE))

--- a/R/getNSetterFunsInternal.R
+++ b/R/getNSetterFunsInternal.R
@@ -31,7 +31,7 @@ sampleExclusionMask <- function(ods, aeMatrix=FALSE){
     
     if(isTRUE(aeMatrix)){
         ans <- as.integer(vapply(ans, isFALSE, FALSE))
-        ans <- matrix(ans, ncol=ncol(ods), nrow=nrow(ods))
+        ans <- matrix(ans, ncol=ncol(ods), nrow=nrow(ods), byrow=TRUE)
         colnames(ans) <- colnames(ods)
         rownames(ans) <- rownames(ods)
     }

--- a/R/method-gridSearch.R
+++ b/R/method-gridSearch.R
@@ -243,7 +243,7 @@ evalAutoCorrection <- function(ods, encoding_dim, BPPARAM=bpparam(), ...){
     ods <- OUTRIDER(ods, controlData=TRUE,q=encoding_dim, BPPARAM=BPPARAM, ...)
     eloss <- evalAucPRLoss(ods)
     
-    print(paste0('Evaluation loss: ', eloss))
+    print(paste0('Evaluation loss: ', eloss,' for q=',encoding_dim))
     return(eloss)
 }
 

--- a/man/sampleExclusionMask.Rd
+++ b/man/sampleExclusionMask.Rd
@@ -14,8 +14,8 @@ sampleExclusionMask(ods) <- value
 \arguments{
 \item{ods}{An OutriderDataSet object}
 
-\item{aeMatrix}{If \code{TRUE}, it returns a 0-1 matrix for the 
-internal autoencoder functions}
+\item{aeMatrix}{If \code{TRUE}, it returns a 0/1 matrix for the 
+internal autoencoder functions in the form of feature x sample}
 
 \item{value}{A logical vector of the length of the samples. If \code{TRUE},
 the corresponding sample will be excluded from the autoencoder

--- a/src/loss_n_gradient_functions.cpp
+++ b/src/loss_n_gradient_functions.cpp
@@ -5,10 +5,13 @@
 #include <Rcpp.h>
 
 const double MIN_EXP_VALUE = -700;
+const double MAX_EXP_VALUE = 700;
 
-arma::mat minValForExp(arma::mat y){
+arma::mat checkRangeForExp(arma::mat y){
     arma::uvec idx = find(y < MIN_EXP_VALUE);
     y.elem(idx).fill(MIN_EXP_VALUE);
+    arma::uvec idx2 = find(y > MAX_EXP_VALUE);
+    y.elem(idx2).fill(MAX_EXP_VALUE);
     return y;
 }
 
@@ -16,7 +19,7 @@ arma::mat minValForExp(arma::mat y){
 arma::mat predictMatY(arma::mat x, arma::mat E, arma::mat D, arma::vec b){
     arma::mat y = x * E * D.t();
     y.each_row() += b.t();
-    y = minValForExp(y);
+    y = checkRangeForExp(y);
     
     return y;
 }
@@ -52,7 +55,7 @@ double truncLogLiklihoodD(arma::vec par, arma::mat H, arma::vec k, arma::vec sf,
     arma::vec thetaVec = theta * thetaC;
     
     y = H * d + b;
-    y = minValForExp(y);
+    y = checkRangeForExp(y);
     
     t1 = k % (arma::log(sf) + y);
     t2 = (k + thetaVec) % (arma::log(sf) + y + arma::log(1 + thetaVec / (sf % arma::exp(y))));
@@ -79,7 +82,7 @@ arma::vec gradientD(arma::vec par, arma::mat H, arma::vec k, arma::vec sf,
     arma::vec thetaVec = theta * thetaC;
     
     y = H * d + b;
-    y = minValForExp(y);
+    y = checkRangeForExp(y);
     yexp = arma::exp(y);
     
     t1 = colMeans(k % H.each_col());

--- a/tests/testthat/test_helper.R
+++ b/tests/testthat/test_helper.R
@@ -36,3 +36,19 @@ test_that("check requirements", {
     counts(ods)[1,2] <- 1
     expect_true(!any(checkCountRequirements(ods)))
 })
+
+test_that("check sample exclusion", {
+    ods <- SummarizedExperiment(assays=SimpleList(
+            a=matrix(1, nrow=16, ncol=11)))
+    expect_false(all(sampleExclusionMask(ods)))
+    expect_equal(length(sampleExclusionMask(ods)), 11)
+    expect_is(sampleExclusionMask(ods, aeMatrix=TRUE), "matrix")
+    expect_equal(dim(sampleExclusionMask(ods, aeMatrix=TRUE)), c(16, 11))
+    
+    vec <- c(logical(5), TRUE, TRUE, logical(4))
+    mat <- do.call(rbind, rep(list((!vec) + 0), 16))
+    
+    sampleExclusionMask(ods) <- vec
+    expect_equal(sampleExclusionMask(ods), vec)
+    expect_equal(sampleExclusionMask(ods, aeMatrix=TRUE), mat)
+})


### PR DESCRIPTION
the wrong exclusion mask matrix output was the main problem, hence the decoder fitted wrong leading to this extreme upper values.
does not fix the increasing loss after PCA but really diminishes the loss jump after PCA (from 6.9 -> 26 to 6.9 -> 7.2)